### PR TITLE
修复了在用户打开CACHE的情况下内存会不断增加的问题

### DIFF
--- a/src/wn_request.c
+++ b/src/wn_request.c
@@ -939,6 +939,9 @@ void webnet_request_destory(struct webnet_request* request)
             if (request->callback) wn_free(request->callback);
             if (request->soap_action) wn_free(request->soap_action);
             if (request->sid) wn_free(request->sid);
+#if (WEBNET_CACHE_LEVEL > 0)
+            if(request->modified) wn_free(request->modified);
+#endif
 #ifdef WEBNET_USING_RANGE
             if (request->Range) wn_free(request->Range);
 #endif /* WEBNET_USING_RANGE */


### PR DESCRIPTION
原版本在用户打开cache的情况下不断刷新页面会导致RAM不断增加直到用光所有内存。
【问题原因】：在打开cache后request结构体会增加一个modified字段，每有一个request会申请一个
modified内存，然而在释放request的时候未删除该段内存，最终会导致内存溢出。