### PR TITLE
修复accept阻塞的问题

### DIFF
--- a/src/webnet.c
+++ b/src/webnet.c
@@ -100,7 +100,11 @@ static void webnet_thread(void *parameter)
     webnet_saddr.sin_port = htons(webnet_port); /* webnet server port */
 
     /* Set receive timeout for accept() */
-    setsockopt(listenfd, SOL_SOCKET, SO_RCVTIMEO, (void*)&rcv_to, sizeof(rcv_to));
+    if(setsockopt(listenfd, SOL_SOCKET, SO_RCVTIMEO, (void*)&rcv_to, sizeof(rcv_to)) == -1)
+    {
+        LOG_E("Set SO_RCVTIMEO failed, errno=%d\n", errno);
+        goto __exit;
+    }
 
     if (bind(listenfd, (struct sockaddr *) &webnet_saddr, sizeof(webnet_saddr)) == -1)
     {

--- a/src/webnet.c
+++ b/src/webnet.c
@@ -99,7 +99,7 @@ static void webnet_thread(void *parameter)
     webnet_saddr.sin_addr.s_addr = htonl(INADDR_ANY);
     webnet_saddr.sin_port = htons(webnet_port); /* webnet server port */
 
-    /* Set receive timeout */
+    /* Set receive timeout for accept() */
     setsockopt (listenfd, SOL_SOCKET, SO_RCVTIMEO, (void*)&rcv_to, sizeof(rcv_to));
 
     if (bind(listenfd, (struct sockaddr *) &webnet_saddr, sizeof(webnet_saddr)) == -1)

--- a/src/webnet.c
+++ b/src/webnet.c
@@ -84,6 +84,7 @@ static void webnet_thread(void *parameter)
     fd_set writeset, tempwrtfds;
     int sock_fd, maxfdp1;
     struct sockaddr_in webnet_saddr;
+    static struct timeval rcv_to = {0, 50000};
 
     /* First acquire our socket for listening for connections */
     listenfd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
@@ -97,6 +98,9 @@ static void webnet_thread(void *parameter)
     webnet_saddr.sin_family = AF_INET;
     webnet_saddr.sin_addr.s_addr = htonl(INADDR_ANY);
     webnet_saddr.sin_port = htons(webnet_port); /* webnet server port */
+
+    /* Set receive timeout */
+    setsockopt (listenfd, SOL_SOCKET, SO_RCVTIMEO, (void*)&rcv_to, sizeof(rcv_to));
 
     if (bind(listenfd, (struct sockaddr *) &webnet_saddr, sizeof(webnet_saddr)) == -1)
     {

--- a/src/webnet.c
+++ b/src/webnet.c
@@ -84,7 +84,7 @@ static void webnet_thread(void *parameter)
     fd_set writeset, tempwrtfds;
     int sock_fd, maxfdp1;
     struct sockaddr_in webnet_saddr;
-    static struct timeval rcv_to = {0, 50000};
+    struct timeval rcv_to = {0, 50000};
 
     /* First acquire our socket for listening for connections */
     listenfd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
@@ -100,7 +100,7 @@ static void webnet_thread(void *parameter)
     webnet_saddr.sin_port = htons(webnet_port); /* webnet server port */
 
     /* Set receive timeout for accept() */
-    setsockopt (listenfd, SOL_SOCKET, SO_RCVTIMEO, (void*)&rcv_to, sizeof(rcv_to));
+    setsockopt(listenfd, SOL_SOCKET, SO_RCVTIMEO, (void*)&rcv_to, sizeof(rcv_to));
 
     if (bind(listenfd, (struct sockaddr *) &webnet_saddr, sizeof(webnet_saddr)) == -1)
     {


### PR DESCRIPTION
设备遇到无法正常访问网页的问题，后经排查发现webnet接入新客户端时因内存不足导致`webnet_session_create()`失败，同时tcp底层重置了新客户端，此时进行accept会阻塞导致页面无法访问，进而还会影响其他已创建的session。我给出的方法是对`listenfd`增加50ms的超时判断
```c
        /* At least one descriptor is ready */
        if (FD_ISSET(listenfd, &tempfds))
        {
            struct webnet_session* accept_session;
            /* We have a new connection request */
            accept_session = webnet_session_create(listenfd);
            if (accept_session == RT_NULL)
            {
                /* create session failed, just accept and then close */
                int sock;
                struct sockaddr cliaddr;
                socklen_t clilen;

                clilen = sizeof(struct sockaddr_in);
                sock = accept(listenfd, &cliaddr, &clilen);//阻塞
                if (sock >= 0)
                {
                    closesocket(sock);
                }
            }
            else
            {
                /* add read fdset */
                FD_SET(accept_session->socket, &readset);
            }
        }
```