### PR TITLE
【修复】修复当基本认证目录设置为'/'时仍可访问 / 目录下的资源问题

### DIFF
--- a/src/wn_utils.c
+++ b/src/wn_utils.c
@@ -40,8 +40,9 @@ rt_inline int tohex(char c)
 
 int str_path_with(const char *s, const char *t)
 {
-    if (strncasecmp(s, t, strlen(t)) == 0
-            && (strlen(s) == strlen(t) || *(s + strlen(t)) == '/')) return 1;
+    if ((strncasecmp(s, t, strlen(t)) == 0
+            && (strlen(s) == strlen(t) || *(s + strlen(t)) == '/'))
+        ||(strlen(t) == 1 && t[0] == '/')) return 1;
 
     return 0;
 }


### PR DESCRIPTION
在当前版本下如果将基本信息认证目录设置为 ‘/’，此时若在地址栏中输入 'host/index.html'时仍可以正常访问页面。本次PR针对此问题进行了修复。