### PR TITLE
解决在KEIL下直接定义_gnuc_引发的平台识别错误

### DIFF
--- a/module/wn_module_upload.c
+++ b/module/wn_module_upload.c
@@ -146,7 +146,7 @@ static char* memstrs(const char* str, size_t length, int num, ...)
     return ptr;
 }
 
-#ifndef __GNUC__
+#if !(defined(__GNUC__) && !defined(__ARMCC_VERSION)/*GCC*/)
 static void* memrchr(const void *s, int c, size_t n)
 {
     register const char* t=s;


### PR DESCRIPTION
https://github.com/RT-Thread-packages/webnet/issues/12