### PR TITLE
[HUST IoTS&P Lab] Update wn_request.c to fix null pointer dereference

### DIFF
--- a/src/wn_request.c
+++ b/src/wn_request.c
@@ -287,6 +287,7 @@ int webnet_request_parse_method(struct webnet_request *request, char* buffer, in
     }
 
     ch = strstr(request_buffer, "\r\n");
+    if (ch == NULL) return 0;
     *ch ++ = '\0';
     *ch ++ = '\0';
     request_buffer = ch;


### PR DESCRIPTION
在src/wn_request.c中的webnet_request_parse_method函数中，当webnet获取的HTTP报文中\r\n不存在于第一行的末尾，将导致原290行空指针解引用，导致解析无法正常进行。

异常报文的内容为："GET /path/to/file\r\n.html HTTP/1.1"

在原文件235行，代码检查报文中是否存在\r\n，上述异常报文可通过检查。随后238行的循环获取报文类型，257行开始获取报文的路径，282行开始获取协议版本，此时request_buffer应指向报文中协议版本处的地址，但后面已经没有\r\n。因此289行的strstr函数调用无法查找到\r\n，返回NULL。随后290行产生空指针解引用。

故289行之后还需添加一个NULL判断。